### PR TITLE
feat(timer): make timer duration editable when idle

### DIFF
--- a/e2e/timer.spec.ts
+++ b/e2e/timer.spec.ts
@@ -2,18 +2,18 @@ import { test, expect } from "./helpers";
 
 test.describe("Timer", () => {
   test("shows default 25:00 timer with START FOCUS button", async ({ page }) => {
-    await expect(page.getByText("25:00")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Set timer duration" })).toHaveValue("25:00");
     await expect(page.getByRole("button", { name: "START FOCUS" })).toBeVisible();
   });
 
   test("switches to Short Break phase", async ({ page }) => {
     await page.getByRole("button", { name: "Short Break" }).click();
-    await expect(page.getByText("05:00")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Set timer duration" })).toHaveValue("05:00");
   });
 
   test("switches to Long Break phase", async ({ page }) => {
     await page.getByRole("button", { name: "Long Break" }).click();
-    await expect(page.getByText("15:00")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Set timer duration" })).toHaveValue("15:00");
   });
 
   test("starts and pauses timer", async ({ page }) => {

--- a/src/components/base/timer-display.tsx
+++ b/src/components/base/timer-display.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Text } from "@/components/ui/text";
 import { formatSeconds } from "@/lib/time";
 import type { TimerPhase } from "@/features/timer/timer-types";
@@ -7,6 +8,8 @@ interface TimerDisplayProps {
   totalSeconds: number;
   phase: TimerPhase;
   overtimeSeconds?: number;
+  editable?: boolean;
+  onDurationChange?: (seconds: number) => void;
 }
 
 const SIZE_DESKTOP = 400;
@@ -16,12 +19,15 @@ const CENTER_DESKTOP = SIZE_DESKTOP / 2;
 const SIZE_MOBILE = 260;
 const RADIUS_MOBILE = 116;
 const CENTER_MOBILE = SIZE_MOBILE / 2;
+const MAX_INPUT_SECONDS = 99 * 60 + 59;
 
 export function TimerDisplay({
   secondsRemaining,
   totalSeconds,
   phase,
   overtimeSeconds = 0,
+  editable = false,
+  onDurationChange,
 }: TimerDisplayProps) {
   const isComplete = secondsRemaining <= 0 || overtimeSeconds > 0;
   const progress =
@@ -36,6 +42,32 @@ export function TimerDisplay({
     2 * Math.PI * RADIUS_MOBILE;
   const offsetMobile =
     circumferenceMobile - (progress / 100) * circumferenceMobile;
+  const [rawInput, setRawInput] = useState(() =>
+    formatEditableValueFromSeconds(secondsRemaining),
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const displayedInputValue = isEditing
+    ? rawInput
+    : formatEditingDisplay(rawInput || "0");
+
+  useEffect(() => {
+    if (!editable || !isEditing) {
+      setRawInput(formatEditableValueFromSeconds(secondsRemaining));
+    }
+  }, [editable, isEditing, secondsRemaining]);
+
+  const commitDuration = (nextRawInput: string) => {
+    if (!editable || !onDurationChange) return;
+
+    const nextSeconds = parseTimeInput(nextRawInput);
+    if (nextSeconds <= 0) {
+      setRawInput(formatEditableValueFromSeconds(secondsRemaining));
+      return;
+    }
+
+    onDurationChange(nextSeconds);
+    setRawInput(formatEditableValueFromSeconds(nextSeconds));
+  };
 
   return (
     <div className="relative inline-flex items-center justify-center">
@@ -139,17 +171,67 @@ export function TimerDisplay({
 
       {/* Center text overlay */}
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <Text
-          variant="timer"
-          className={cn(
-            isComplete ? "text-amber-600" : "text-sahara-primary",
-            "md:text-[120px] text-[76px]",
-          )}
-        >
-          {isComplete
-            ? `+${formatSeconds(totalSeconds + overtimeSeconds)}`
-            : formatSeconds(secondsRemaining)}
-        </Text>
+        {editable && !isComplete ? (
+          <label className="group flex items-center justify-center">
+            <span className="sr-only">Set timer duration</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9:]{0,2}(:[0-9]{0,2})?"
+              aria-label="Set timer duration"
+              value={displayedInputValue}
+              onChange={(event) => {
+                const nextRawInput = sanitizeTimeInput(event.target.value);
+                setRawInput(nextRawInput);
+
+                const nextSeconds = parseTimeInput(nextRawInput);
+                if (nextSeconds > 0) {
+                  onDurationChange?.(nextSeconds);
+                }
+              }}
+              onFocus={(event) => {
+                setIsEditing(true);
+                requestAnimationFrame(() => {
+                  const length = event.target.value.length;
+                  event.target.setSelectionRange(length, length);
+                });
+              }}
+              onBlur={() => {
+                setIsEditing(false);
+                commitDuration(rawInput);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.currentTarget.blur();
+                }
+
+                if (event.key === "Escape") {
+                  setRawInput(formatEditableValueFromSeconds(secondsRemaining));
+                  setIsEditing(false);
+                  event.currentTarget.blur();
+                }
+              }}
+              className={cn(
+                "w-[5.5ch] rounded-2xl border border-transparent bg-transparent px-3 md:px-4 text-center font-serif leading-none tracking-tight text-sahara-primary outline-none transition-all [font-variant-numeric:tabular-nums]",
+                "text-[76px] md:text-[120px]",
+                "hover:border-sahara-primary/20 hover:bg-sahara-primary/5",
+                "focus:border-sahara-primary/30 focus:bg-sahara-primary/8 focus:shadow-[0_0_0_1px_rgba(194,101,42,0.12)]",
+              )}
+            />
+          </label>
+        ) : (
+          <Text
+            variant="timer"
+            className={cn(
+              isComplete ? "text-amber-600" : "text-sahara-primary",
+              "md:text-[120px] text-[76px]",
+            )}
+          >
+            {isComplete
+              ? `+${formatSeconds(totalSeconds + overtimeSeconds)}`
+              : formatSeconds(secondsRemaining)}
+          </Text>
+        )}
         <p className="text-[10px] tracking-[0.3em] font-bold text-sahara-text-muted mt-1 md:mt-2 uppercase">
           {isComplete
             ? "Overtime"
@@ -166,4 +248,47 @@ export function TimerDisplay({
 
 function cn(...classes: (string | undefined | null | false)[]) {
   return classes.filter(Boolean).join(" ");
+}
+
+function sanitizeTimeInput(value: string): string {
+  const cleaned = value.replace(/[^\d:]/g, "");
+  const [minutesPart = "", secondsPart = ""] = cleaned.split(":");
+  const hasColon = cleaned.includes(":");
+  const minutes = minutesPart.slice(0, 2);
+  const seconds = secondsPart.slice(0, 2);
+
+  return hasColon ? `${minutes}:${seconds}` : minutes;
+}
+
+function parseTimeInput(value: string): number {
+  if (!value) return 0;
+
+  if (!value.includes(":")) {
+    return Math.min(MAX_INPUT_SECONDS, Number(value) * 60);
+  }
+
+  const [minutesPart = "0", secondsPart = "0"] = value.split(":");
+  const minutes = Number(minutesPart || "0");
+  const seconds = Number(secondsPart || "0");
+
+  return Math.min(MAX_INPUT_SECONDS, minutes * 60 + seconds);
+}
+
+function formatEditableValueFromSeconds(totalSeconds: number): string {
+  const bounded = Math.max(0, Math.min(MAX_INPUT_SECONDS, Math.floor(totalSeconds)));
+  const minutes = Math.floor(bounded / 60).toString().padStart(2, "0");
+  const seconds = bounded % 60;
+
+  return seconds === 0 ? minutes : `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatEditingDisplay(value: string): string {
+  if (!value) return "00:00";
+
+  if (!value.includes(":")) {
+    return `${value.padStart(2, "0")}:00`;
+  }
+
+  const [minutesPart = "0", secondsPart = ""] = value.split(":");
+  return `${minutesPart.padStart(2, "0")}:${secondsPart.padEnd(2, "0")}`;
 }

--- a/src/components/base/timer-display.tsx
+++ b/src/components/base/timer-display.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Text } from "@/components/ui/text";
 import { formatSeconds } from "@/lib/time";
 import type { TimerPhase } from "@/features/timer/timer-types";
@@ -46,6 +46,8 @@ export function TimerDisplay({
     formatEditableValueFromSeconds(secondsRemaining),
   );
   const [isEditing, setIsEditing] = useState(false);
+  const originalSecondsRef = useRef(secondsRemaining);
+  const cancelledRef = useRef(false);
   const displayedInputValue = isEditing
     ? rawInput
     : formatEditingDisplay(rawInput || "0");
@@ -190,6 +192,8 @@ export function TimerDisplay({
                 }
               }}
               onFocus={(event) => {
+                originalSecondsRef.current = secondsRemaining;
+                cancelledRef.current = false;
                 setIsEditing(true);
                 requestAnimationFrame(() => {
                   const length = event.target.value.length;
@@ -198,7 +202,9 @@ export function TimerDisplay({
               }}
               onBlur={() => {
                 setIsEditing(false);
-                commitDuration(rawInput);
+                if (!cancelledRef.current) {
+                  commitDuration(rawInput);
+                }
               }}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
@@ -206,7 +212,9 @@ export function TimerDisplay({
                 }
 
                 if (event.key === "Escape") {
-                  setRawInput(formatEditableValueFromSeconds(secondsRemaining));
+                  cancelledRef.current = true;
+                  onDurationChange?.(originalSecondsRef.current);
+                  setRawInput(formatEditableValueFromSeconds(originalSecondsRef.current));
                   setIsEditing(false);
                   event.currentTarget.blur();
                 }

--- a/src/components/containers/timer-controls.tsx
+++ b/src/components/containers/timer-controls.tsx
@@ -34,6 +34,9 @@ export function TimerControls() {
   const reset = useTimerStore((s) => s.reset);
   const setPhase = useTimerStore((s) => s.setPhase);
   const adjustDuration = useTimerStore((s) => s.adjustDuration);
+  const setDurationForCurrentPhase = useTimerStore(
+    (s) => s.setDurationForCurrentPhase,
+  );
   const finishSession = useTimerStore((s) => s.finishSession);
   const abandonSession = useTimerStore((s) => s.abandonSession);
   const selectedCategory = useTimerStore((s) => s.selectedCategory);
@@ -109,6 +112,8 @@ export function TimerControls() {
         totalSeconds={totalSeconds}
         phase={phase}
         overtimeSeconds={overtimeSeconds}
+        editable={status === "idle"}
+        onDurationChange={setDurationForCurrentPhase}
       />
 
       {/* Duration Adjuster with Time Range */}

--- a/src/features/timer/use-timer-store.test.ts
+++ b/src/features/timer/use-timer-store.test.ts
@@ -160,6 +160,31 @@ describe("useTimerStore", () => {
     });
   });
 
+  describe("setDurationForCurrentPhase", () => {
+    it("updates only the active phase duration when idle", () => {
+      useTimerStore.getState().setPhase("short_break");
+      useTimerStore.getState().setDurationForCurrentPhase(95);
+
+      const state = useTimerStore.getState();
+      expect(state.durations.work).toBe(DEFAULT_WORK_SEC);
+      expect(state.durations.short).toBe(95);
+      expect(state.durations.long).toBe(DEFAULT_LONG_BREAK_SEC);
+      expect(state.secondsRemaining).toBe(95);
+      expect(state.totalSeconds).toBe(95);
+    });
+
+    it("does not change duration during an active session", async () => {
+      await useTimerStore.getState().start();
+
+      useTimerStore.getState().setDurationForCurrentPhase(95);
+
+      const state = useTimerStore.getState();
+      expect(state.durations.work).toBe(DEFAULT_WORK_SEC);
+      expect(state.secondsRemaining).toBe(DEFAULT_WORK_SEC);
+      expect(state.totalSeconds).toBe(DEFAULT_WORK_SEC);
+    });
+  });
+
   describe("reset", () => {
     it("resets to idle with correct phase duration", async () => {
       useTimerStore.getState().setPhase("short_break");

--- a/src/features/timer/use-timer-store.ts
+++ b/src/features/timer/use-timer-store.ts
@@ -48,6 +48,7 @@ interface TimerStore {
   setPhase: (phase: TimerPhase) => void;
   setActiveTask: (taskId: number | null) => void;
   setDurations: (work: number, short: number, long: number) => void;
+  setDurationForCurrentPhase: (seconds: number) => void;
   adjustDuration: (minutes: number) => void;
   finishSession: (mood?: string, notes?: string) => Promise<void>;
   abandonSession: () => Promise<void>;
@@ -64,6 +65,10 @@ function getPhaseDuration(
   return durations[
     phase === "work" ? "work" : phase === "short_break" ? "short" : "long"
   ];
+}
+
+function getPhaseDurationKey(phase: TimerPhase): keyof TimerDurations {
+  return phase === "work" ? "work" : phase === "short_break" ? "short" : "long";
 }
 
 function getNextPhase(
@@ -288,10 +293,24 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
     }
   },
 
+  setDurationForCurrentPhase: (seconds: number) => {
+    const { status, phase, durations } = get();
+    if (status !== "idle") return;
+
+    const nextDuration = Math.max(1, Math.floor(seconds));
+    const key = getPhaseDurationKey(phase);
+    const nextDurations = { ...durations, [key]: nextDuration };
+
+    set({
+      durations: nextDurations,
+      secondsRemaining: nextDuration,
+      totalSeconds: nextDuration,
+    });
+  },
+
   adjustDuration: (minutes: number) => {
     const { status, worker, phase, durations } = get();
-    const key =
-      phase === "work" ? "work" : phase === "short_break" ? "short" : "long";
+    const key = getPhaseDurationKey(phase);
 
     if (status === "idle") {
       const currentDuration = durations[key];


### PR DESCRIPTION
## Description
Make the timer display directly editable when the timer is idle, allowing users to type a custom duration instead of only using the preset adjusters.

When the timer is in an idle state, the center timer text is replaced with an inline text input. Users can type a duration in `MM:SS` or `MM` format. The input supports focus/blur, Enter to commit, and Escape to cancel. Changes are committed to the timer store only when valid. The existing duration slider adjuster continues to work alongside this new inline editor.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Fixes #1

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

### Test Results
- Unit tests for `setDurationForCurrentPhase` were added and pass (verifies duration updates only when idle, and no-ops during an active session).
- E2E timer spec assertions were updated to match the new editable input (`getByRole("textbox")` instead of `getByText`).
- Manual testing confirmed: clicking the timer input focuses it, typing a new duration updates the timer, Enter commits, Escape reverts, and blur commits.

## Screenshots (if applicable)

## Additional Notes
- The `TimerDisplay` component now accepts `editable` and `onDurationChange` props (both optional, defaulting to `false`/`undefined`), so existing non-editable usages are unaffected.
- A new `setDurationForCurrentPhase` action was added to the timer store, alongside the existing `adjustDuration` action (which remains unchanged for the slider controls).
- Input is capped at `99:59` via `MAX_INPUT_SECONDS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timer duration can now be edited directly from the timer display when the timer is idle.

* **Tests**
  * Added unit test coverage for timer duration setting functionality.
  * Updated timer display tests to validate duration input accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->