### PR TITLE
fix(ci): preserve custom release notes — upload assets without overwriting body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -185,58 +189,31 @@ jobs:
           echo "=== Release files ==="
           ls -lh release-files/
 
-      - name: Generate release notes
-        id: release_notes
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
-          NOTES_FILE="/tmp/release-notes.md"
 
-          {
-            echo "## Kairos-Pomodoro ${TAG}"
-            echo ""
-            echo "### Downloads"
-            echo ""
-            echo "| Platform | File |"
-            echo "|----------|------|"
-            for f in release-files/*.{dmg,exe,AppImage,msix}; do
-              if [ -f "$f" ]; then
-                filename=$(basename "$f")
-                size=$(du -h "$f" | cut -f1)
-                echo "| \`${filename}\` | ${size} |"
-              fi
-            done
-            echo ""
-            echo "---"
-            echo ""
-            echo "**MIT Licensed. Built with Tauri + React + TypeScript.**"
-            echo ""
-            echo "### macOS Users — First Launch"
-            echo ""
-            echo "If you see a security warning on first launch:"
-            echo '```sh'
-            echo "xattr -cr /Applications/Kairos-Pomodoro.app"
-            echo '```'
-            echo ""
-            echo "Or right-click the app → **Open** (instead of double-clicking)."
-            echo ""
-            echo "### Verify Integrity"
-            echo '```sh'
-            echo "sha256sum *.dmg *.exe *.AppImage *.msix 2>/dev/null || true"
-            echo '```'
-          } > "${NOTES_FILE}"
-
-          {
-            echo "notes<<RELEASE_NOTES_EOF"
-            cat "${NOTES_FILE}"
-            echo "RELEASE_NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: ${{ steps.release_notes.outputs.notes }}
-          draft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
-          files: release-files/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if gh release view "${TAG}" &>/dev/null 2>&1; then
+            echo "Release ${TAG} exists — uploading assets only..."
+            gh release upload "${TAG}" release-files/* --clobber
+          else
+            echo "Creating release ${TAG}..."
+            PREV_TAG="$(git tag --sort=-creatordate | head -2 | tail -1)"
+            IS_PRERELEASE="false"
+            if [[ "${TAG}" == *-beta* || "${TAG}" == *-rc* ]]; then
+              IS_PRERELEASE="true"
+            fi
+            NOTES_ARGS=()
+            if [ -n "$PREV_TAG" ]; then
+              NOTES_ARGS+=(--notes-start-tag "$PREV_TAG")
+            fi
+            gh release create "${TAG}" \
+              release-files/* \
+              --title "Kairos-Pomodoro ${TAG}" \
+              --generate-notes \
+              "${NOTES_ARGS[@]}" \
+              --prerelease "${IS_PRERELEASE}"
+          fi


### PR DESCRIPTION
## Summary

The `release` job was overwriting manually-written release notes with bare file listings via `softprops/action-gh-release`.

**Before:** Custom notes (feature descriptions, changelog) were destroyed on every CI run.

**After:** The workflow checks if a release already exists at the tag:
- **Exists** → uploads assets only (preserves notes)
- **Doesn't exist** → creates with GitHub auto-generated notes from commits

This also removes the outdated `softprops/action-gh-release@v2` dependency in favor of direct `gh` CLI commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release process automation to enable more reliable and consistent release creation and asset management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakibdshy/Kairos-Pomodoro/pull/13)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->